### PR TITLE
Fix README.md for API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The different with `runCommand` is that it can get the command run standard outp
 
 execute next kotlin code
 ```kotlin
-val date = "date".evalBash().getOrThrow()  //execute shell command `date` and get the command's output and set the content to date variable
+val date = evalBash("date").getOrThrow()  //execute shell command `date` and get the command's output and set the content to date variable
 println(date) //This will print Fri Aug 19 21:59:56 CEST 2022 on console
 val year = date.substringAfterLast(" ") // will get 2022 and assign to `year`
 println(year)


### PR DESCRIPTION
It seems the API for evalBash changed. If you use "".evalBash() then there are build errors because the `env` param is non-optional in that extension function.